### PR TITLE
57 deepracer analysis not showing unique episodes on some pages

### DIFF
--- a/spot-instance.yaml
+++ b/spot-instance.yaml
@@ -12,7 +12,7 @@ Parameters:
     Description: timeout in minutes after which training is stopped and this stack is deleted
     Default: 60
     MinValue: 10
-    MaxValue: 1440 # 24 hours
+    MaxValue: 4001 # 24 hours
   AmiId:
     Type: String
     Description: the AMI we want to launch an ec2 instance against. By default this is the image created by central account 747447086422 owned by Tyler Wooten
@@ -226,8 +226,7 @@ Resources:
               content: |
                 <!DOCTYPE html>
                 <html>
-                <body>
-                                
+                <body>       
                 <h2>Training analysis is typically available 20-30 minutes into training.  Please refresh in a few minutes. </h2>
                 </body>
                 </html>
@@ -238,8 +237,7 @@ Resources:
               content: |
                 <!DOCTYPE html>
                 <html>
-                <body>
-                                
+                <body>    
                 <h2>Training analysis is typically available 20-30 minutes into training.  Please refresh in a few minutes. </h2>
                 </body>
                 </html>
@@ -250,8 +248,7 @@ Resources:
               content: |
                 <!DOCTYPE html>
                 <html>
-                <body>
-                                
+                <body>        
                 <h2>Training analysis is typically available 20-30 minutes into training.  Please refresh in a few minutes. </h2>
                 </body>
                 </html>
@@ -262,8 +259,7 @@ Resources:
               content: |
                 <!DOCTYPE html>
                 <html>
-                <body>
-                                
+                <body>        
                 <h2>Training analysis is typically available 20-30 minutes into training.  Please refresh in a few minutes. </h2>
                 </body>
                 </html>
@@ -274,8 +270,7 @@ Resources:
               content: |
                 <!DOCTYPE html>
                 <html>
-                <body>
-                                
+                <body>        
                 <h2>Training analysis is typically available 20-30 minutes into training.  Please refresh in a few minutes. </h2>
                 </body>
                 </html>
@@ -286,8 +281,7 @@ Resources:
               content: |
                 <!DOCTYPE html>
                 <html>
-                <body>
-                                
+                <body>         
                 <h2>Training analysis is typically available 20-30 minutes into training.  Please refresh in a few minutes. </h2>
                 </body>
                 </html>

--- a/spot-instance.yaml
+++ b/spot-instance.yaml
@@ -4,7 +4,7 @@ Description: Setup a spot EC2 Autoscaling Group for deep racer
 Parameters:
   InstanceType:
     Type: String
-    Default: g4dn.2xlarge
+    Default: g4dn.4xlarge
   ResourcesStackName:
     Type: String
   TimeToLiveInMinutes:
@@ -579,7 +579,7 @@ Resources:
                   log = DeepRacerLog(filehandler=fh)
                   log.load_training_trace()
                   df = log.dataframe()
-                  simulation_agg = au.simulation_agg(df)
+                  simulation_agg = au.simulation_agg(df, secondgroup="unique_episode")
                   complete_ones = simulation_agg[simulation_agg['progress']==100]
                   %store df
                   %store simulation_agg
@@ -900,14 +900,14 @@ Resources:
 
                 # +
                 episodes_to_plot = complete_ones.nsmallest(5, 'time')
-                pu.plot_selected_laps(episodes_to_plot, df, track)
+                pu.plot_selected_laps(episodes_to_plot, df, track, section_to_plot="unique_episode")
                 # -
 
                 # ## Path taken for highest rewarded complete laps
                 
                 # +
                 episodes_to_plot = complete_ones.nlargest(5,'reward')
-                pu.plot_selected_laps(episodes_to_plot, df, track)
+                pu.plot_selected_laps(episodes_to_plot, df, track, section_to_plot="unique_episode")
                 # -
               mode : "000755"
               owner: ubuntu

--- a/spot-instance.yaml
+++ b/spot-instance.yaml
@@ -4,7 +4,7 @@ Description: Setup a spot EC2 Autoscaling Group for deep racer
 Parameters:
   InstanceType:
     Type: String
-    Default: g4dn.4xlarge
+    Default: g4dn.2xlarge
   ResourcesStackName:
     Type: String
   TimeToLiveInMinutes:
@@ -12,7 +12,7 @@ Parameters:
     Description: timeout in minutes after which training is stopped and this stack is deleted
     Default: 60
     MinValue: 10
-    MaxValue: 4001 # 24 hours
+    MaxValue: 1440 # 24 hours
   AmiId:
     Type: String
     Description: the AMI we want to launch an ec2 instance against. By default this is the image created by central account 747447086422 owned by Tyler Wooten

--- a/standard-instance.yaml
+++ b/standard-instance.yaml
@@ -185,8 +185,7 @@ Resources:
               content: |
                 <!DOCTYPE html>
                 <html>
-                <body>
-                                
+                <body>    
                 <h2>Training analysis is typically available 20-30 minutes into training.  Please refresh in a few minutes. </h2>
                 </body>
                 </html>
@@ -197,8 +196,7 @@ Resources:
               content: |
                 <!DOCTYPE html>
                 <html>
-                <body>
-                                
+                <body>    
                 <h2>Training analysis is typically available 20-30 minutes into training.  Please refresh in a few minutes. </h2>
                 </body>
                 </html>
@@ -209,8 +207,7 @@ Resources:
               content: |
                 <!DOCTYPE html>
                 <html>
-                <body>
-                                
+                <body>  
                 <h2>Training analysis is typically available 20-30 minutes into training.  Please refresh in a few minutes. </h2>
                 </body>
                 </html>
@@ -221,8 +218,7 @@ Resources:
               content: |
                 <!DOCTYPE html>
                 <html>
-                <body>
-                                
+                <body>   
                 <h2>Training analysis is typically available 20-30 minutes into training.  Please refresh in a few minutes. </h2>
                 </body>
                 </html>
@@ -234,7 +230,6 @@ Resources:
                 <!DOCTYPE html>
                 <html>
                 <body>
-                                
                 <h2>Training analysis is typically available 20-30 minutes into training.  Please refresh in a few minutes. </h2>
                 </body>
                 </html>
@@ -245,8 +240,7 @@ Resources:
               content: |
                 <!DOCTYPE html>
                 <html>
-                <body>
-                                
+                <body> 
                 <h2>Training analysis is typically available 20-30 minutes into training.  Please refresh in a few minutes. </h2>
                 </body>
                 </html>

--- a/standard-instance.yaml
+++ b/standard-instance.yaml
@@ -540,7 +540,7 @@ Resources:
                   log = DeepRacerLog(filehandler=fh)
                   log.load_training_trace()
                   df = log.dataframe()
-                  simulation_agg = au.simulation_agg(df)
+                  simulation_agg = au.simulation_agg(df, secondgroup="unique_episode")
                   complete_ones = simulation_agg[simulation_agg['progress']==100]
                   %store df
                   %store simulation_agg
@@ -861,14 +861,14 @@ Resources:
 
                 # +
                 episodes_to_plot = complete_ones.nsmallest(5, 'time')
-                pu.plot_selected_laps(episodes_to_plot, df, track)
+                pu.plot_selected_laps(episodes_to_plot, df, track, section_to_plot="unique_episode")
                 # -
 
                 # ## Path taken for highest rewarded complete laps
                 
                 # +
                 episodes_to_plot = complete_ones.nlargest(5,'reward')
-                pu.plot_selected_laps(episodes_to_plot, df, track)
+                pu.plot_selected_laps(episodes_to_plot, df, track, section_to_plot="unique_episode")
                 # -
               mode : "000755"
               owner: ubuntu


### PR DESCRIPTION
Fix to the Deepracer analysis web pages powered by the Jupyter notebook.  I noticed when using lots of workers I was seeing odd behaviour in the logs, which the below resolves.  The other changes are to delete some spaces, as we're verging on the limit of a CloudFormation template size without preloading it to S3.

Example of fixes: -

Before with 8 workers trying to see fastest lap path shows every worker's episode of that number
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/370f019f-0481-44f7-9478-31ad89fe0e04)
After we only have the unique episode we want: -
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/16f4326c-4998-4e78-86bf-28bb52442243)


Before with 8 workers the data tables were adding up the laptimes and rewards of the multiple workers: -
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/d61972c0-421b-42de-94d5-e49a07e30e64)

After we only have the details of the individual episode: -
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/6f2becf7-818d-4655-8fc8-3890e9f4f177)
