### PR TITLE
Use python3 for reward function validation

### DIFF
--- a/create-base-resources.sh
+++ b/create-base-resources.sh
@@ -9,7 +9,7 @@ ip=$1
 shift
 
 function generate_rule_number() {
-        exisiting_rule_numbers=$(aws ec2 describe-network-acls | grep RuleNumber | tr -d ' ' | awk -F ':' '{ print $2 }' | sort -u)
+        existing_rule_numbers=$(aws ec2 describe-network-acls | grep RuleNumber | tr -d ' ' | awk -F ':' '{ print $2 }' | sort -u)
 	rule_number_candidate=$(shuf -i 1-32000 -n 1)
 	while [[ 0 -ne $(echo $existing_rule_numbers | tr ' ' '\n' | grep -xc $rule_number_candidate) ]];do
 	        rule_number_candidate=$(shuf -i 1-32000 -n 1)

--- a/create-spot-instance.sh
+++ b/create-spot-instance.sh
@@ -29,7 +29,7 @@ if [[ $? -ne 0 ]]; then
         echo -e "\e[1;33m  ##########  Error found in reward_function.py, want to continue anyway? \e[0m"
         read -p "[y / n]: " yn
         case $yn in
-            [Yy]* ) make install; break;;
+            [Yy]* ) break;;
             [Nn]* ) exit;;
             * ) echo "Please answer yes or no.";;
         esac

--- a/create-standard-instance.sh
+++ b/create-standard-instance.sh
@@ -29,7 +29,7 @@ if [[ $? -ne 0 ]]; then
         echo -e "\e[1;33m  ##########  Error found in reward_function.py, want to continue anyway? \e[0m"
         read -p "[y / n]: " yn
         case $yn in
-            [Yy]* ) make install; break;;
+            [Yy]* ) break;;
             [Nn]* ) exit;;
             * ) echo "Please answer yes or no.";;
         esac

--- a/validation.sh
+++ b/validation.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-python -m py_compile custom-files/reward_function.py
+python3 -m py_compile custom-files/reward_function.py
 if [ $? -eq 1 ]; then echo "error in reward_function.py" && exit 1; fi
 jq -e < custom-files/model_metadata.json
 if [ $? -eq 4 ]; then echo "error in model_metadata.json" && exit 1; fi


### PR DESCRIPTION
Used python3 for reward function validation; also removed "make install" from create-spot-instance.sh and create-standard-instance.sh since no Makefile exists in the project now. Additionally, fixed a typo in create-base-resources.sh.