### PR TITLE
update-python-runtimes

### DIFF
--- a/base-resources.yaml
+++ b/base-resources.yaml
@@ -338,7 +338,7 @@ Resources:
     Properties:
       Handler: index.handler
       Role: !GetAtt FutureTimeCronExpressionLambdaRole.Arn
-      Runtime: python3.7
+      Runtime: python3.11
       Code:
         ZipFile: |
           import cfnresponse
@@ -396,7 +396,7 @@ Resources:
     Properties:
       Role: !GetAtt TerminationLambdaRole.Arn
       Handler: index.handler
-      Runtime: python3.7
+      Runtime: python3.11
       Timeout: 900
       Code:
         ZipFile: !Sub |

--- a/scripts/image-builder.yaml
+++ b/scripts/image-builder.yaml
@@ -504,7 +504,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.7
+      Runtime: python3.11
       InlineCode: !Sub |
         import json
         import boto3
@@ -576,7 +576,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.7
+      Runtime: python3.11
       InlineCode: !Sub |
         import json
         import boto3

--- a/spot-instance.yaml
+++ b/spot-instance.yaml
@@ -1022,7 +1022,7 @@ Resources:
                   print(e.response['Error']['Message'])
               notification_topic = os.environ['INTERRUPTION_NOTIFICATION']
               sns_client.publish(TopicArn=notification_topic, Message=f'Termination notification instance: {instance_id} stack: ${AWS::StackName}')
-      Runtime: python3.7
+      Runtime: python3.11
       Timeout: 120
       Environment:
         Variables:


### PR DESCRIPTION
Fix for - https://github.com/aws-deepracer-community/deepracer-on-the-spot/issues/77

Updated python runtimes from 3.7 to 3.11 for base, spot and image builder.

Tested all Lambdas still function as before.
Base resources updated: -
 
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/d8c5dd92-6660-4258-ab3f-59286906bbab)


SpotInterruptionHandler updated: -
 
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/78ba15d6-8e12-423b-9a66-80be0a38c001)


FutureTimeCronExpression works: -
 
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/2ad9fc0b-2f6b-48d8-b5e8-515dee35aff5)


SpotInterruptionHandler works: -
 
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/e074b604-eff6-4cc2-8137-65e7b847c13c)
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/67ca076c-7030-4344-a950-c7fa3d9887e7)

 
Termination works: -
 
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/d1f0cb2a-4901-4796-8cef-f8b1311b9238)
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/aed760cf-32f6-494e-bce6-679f68d2e05e)
 
ImageBuilder updated: -
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/7c37e6d2-ac37-4287-85b4-8933b02aa8ee)

 
ImageBuilder-UpdateSSM works the same as before: -
On first run ‘KeyError’ is consistent with Python 3.7 first runs, as there is no existing image
 
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/5a9e08e8-0a36-4a9b-97d8-e875ad467a59)

Subsequent runs find the image, again this is consistent with Python 3.7 behaviour
 
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/87abc670-01be-495f-bf2c-575a6b45343a)


ImageBuilder-DeleteOldAMIs works: -
On first run ‘KeyError’ is consistent with Python 3.7 first runs, as there is no existing image
 
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/f9e01822-f4c9-4324-a260-a57aa5f9e3f6)

On subsequent runs the same behaviour as before is exhibited, it finds the snapshots but cannot delete due to in-use AMI (i'll log an issue for this in general, not related to the python 3.7 to 3.11 upgrade)
 
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/d59ed99e-6cc6-4823-8376-eb2349010e9f)

@tylerwooten can you review please?