### PR TITLE
bugfix-align-episodes

### DIFF
--- a/custom-files/README.md
+++ b/custom-files/README.md
@@ -8,7 +8,7 @@
 * `exploration_type`: `categorical` or `additive_noise`.
 * `loss_type`: `huber` or `mean squared error`. Default is `huber`.
 * `lr`: Values between `0.00000001` and `0.001` (inclusive). Default is `0.0003`.
-* `num_episodes_between_training`: Integer between `5` and `100` (inclusive). Default is `20`.
+* `num_episodes_between_training`: Integer between `5` and `100` (inclusive). To avoid issues with the position from which evaluations are run ensure that ( num_episodes_between_training / DR_WORKERS) * DR_TRAIN_ROUND_ROBIN_ADVANCE_DIST = 1.0.  As default DR_WORKERS is 2 and DR_TRAIN_ROUND_ROBIN_ADVANCE_DIST is 0.05 the default value is `40`.
 * `num_epochs`: Values between `3` and `10` (inclusive). Default is `3`.
 * `stack_size`: Default is `1`.
 * `term_cond_avg_score`: Values between `35000.0` and `100000.0`.

--- a/custom-files/hyperparameters.json
+++ b/custom-files/hyperparameters.json
@@ -7,7 +7,7 @@
   "exploration_type": "categorical",
   "loss_type": "huber",
   "lr": 0.0003,
-  "num_episodes_between_training": 20,
+  "num_episodes_between_training": 40,
   "num_epochs": 10,
   "stack_size": 1,
   "term_cond_avg_score": 35000.0,


### PR DESCRIPTION
There is a formula to calculate workers, episodes and round robin distance: -
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/0ffe877a-d5df-4dee-9216-cd3eb0f2b8b0)

The default DOTS parameters didn't follow that formula.  As the default workers is 2 to maximise use of g4dn.2xlarge default instances and 0.05 round robin distance matches the console experience of moving 5% along the track per episode the fix is to increase episodes to 40 so each worker gets 20 episodes per iteration.