### PR TITLE
error handling for preexisting quota

### DIFF
--- a/base-resources.yaml
+++ b/base-resources.yaml
@@ -513,16 +513,30 @@ Resources:
           def handler(event, context):
               if event['RequestType'] == 'Create':
                 try:
-                  spot_response = client.request_service_quota_increase(
+                  existing_spot_quota = client.get_service_quota(
                       ServiceCode='ec2',
-                      QuotaCode='L-3819A6DF',
-                      DesiredValue=16
+                      QuotaCode='L-3819A6DF'
                   )
-                  ondemand_response = client.request_service_quota_increase(
+                  if existing_spot_quota['Quota']['Value'] < 16:
+                    spot_response = client.request_service_quota_increase(
+                        ServiceCode='ec2',
+                        QuotaCode='L-3819A6DF',
+                        DesiredValue=16
+                    )
+                  else:
+                    spot_response="Existing spot quota is already sufficient"
+                  existing_ondemand_quota = client.get_service_quota(
                       ServiceCode='ec2',
-                      QuotaCode='L-DB2E81BA',
-                      DesiredValue=16
+                      QuotaCode='L-DB2E81BA'
                   )
+                  if existing_ondemand_quota['Quota']['Value'] < 16:
+                    ondemand_response = client.request_service_quota_increase(
+                        ServiceCode='ec2',
+                        QuotaCode='L-DB2E81BA',
+                        DesiredValue=16
+                    )
+                  else:
+                    ondemand_response="Existing on-demand quota is already sufficient"
                   logger.info('Printing event: {}'.format(spot_response))
                   logger.info('Printing event: {}'.format(ondemand_response))
                   responseData = {}


### PR DESCRIPTION
Updated base resources causes an error for users who already have a quota higher than the one being requested.  Added error handling to the code to skip quota request if it's already higher than the quota the code is going to request.

In this example the account had 16 vpu of spot and 8 of ondemand, so spot now skips and only the on dmeand quota request is processed: -
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/b8917835-276c-4508-a695-33a073b94ac6)

Stack deploy as expected: -
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/70a7b0db-b970-4a4f-a007-4b8ca106f55c)
