### PR TITLE
additional-analysis

### DIFF
--- a/spot-instance.yaml
+++ b/spot-instance.yaml
@@ -848,6 +848,13 @@ Resources:
                 complete_ones.nsmallest(10, 'time')
                 # -
 
+                # ## Ten fastest complete laps from the start/finish line in training
+
+                # +
+                complete_ones_from_start = complete_ones[complete_ones['start_at']==1]
+                complete_ones_from_start.nsmallest(10, 'time')
+                # -
+
                 # ## Ten fastest incomplete laps in the training
 
                 # +
@@ -976,6 +983,7 @@ Resources:
                   ev=tm.getEvaluation()
                   train_complete_lr = train[(train['round']>(0)) & (train['complete']==1)]
                   eval_complete_lr = ev[(ev['round']>(0)) & (ev['complete']==1)]
+                  rolling_lap = tm.plotProgress(method=['min','mean'],rolling_average=15, figsize=(20,5), series=[('eval_time','Evaluation','orange'),('train_time','Training','blue')], title="Laptime for completed laps over last 15 episodes ({}).", ylabel="Laptime", completedLapsOnly=True, grid=True)
                   plt.figure(figsize=(15,5))
                   plt.title('Best lap progression')
                   plt.scatter(train_complete_lr['master_iteration'],train_complete_lr['time'],alpha=0.4)

--- a/standard-instance.yaml
+++ b/standard-instance.yaml
@@ -809,6 +809,13 @@ Resources:
                 complete_ones.nsmallest(10, 'time')
                 # -
 
+                # ## Ten fastest complete laps from the start/finish line in training
+
+                # +
+                complete_ones_from_start = complete_ones[complete_ones['start_at']==1]
+                complete_ones_from_start.nsmallest(10, 'time')
+                # -
+
                 # ## Ten fastest incomplete laps in the training
 
                 # +
@@ -937,6 +944,7 @@ Resources:
                   ev=tm.getEvaluation()
                   train_complete_lr = train[(train['round']>(0)) & (train['complete']==1)]
                   eval_complete_lr = ev[(ev['round']>(0)) & (ev['complete']==1)]
+                  rolling_lap = tm.plotProgress(method=['min','mean'],rolling_average=15, figsize=(20,5), series=[('eval_time','Evaluation','orange'),('train_time','Training','blue')], title="Laptime for completed laps over last 15 episodes ({}).", ylabel="Laptime", completedLapsOnly=True, grid=True)
                   plt.figure(figsize=(15,5))
                   plt.title('Best lap progression')
                   plt.scatter(train_complete_lr['master_iteration'],train_complete_lr['time'],alpha=0.4)


### PR DESCRIPTION
Added some additional analysis.

1) A table with the quickest lap times from waypoint 1, i.e. the start / finish line: -
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/d37c0d10-9135-4b86-bc88-15adb48c8b63)

2) a rolling average of the last 15 episodes for the quickest lap and the mean average lap, to help understand if lap time performance is improving over time: -
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/023fb7f1-29c8-4e00-991d-b1c48839f7d9)
