### PR TITLE
Percentile Analysis

### DIFF
--- a/spot-instance.yaml
+++ b/spot-instance.yaml
@@ -967,6 +967,7 @@ Resources:
                 from deepracer.logs import metrics
                 import matplotlib.pyplot as plt
                 import numpy as np
+                import pandas as pd
 
                 # Ignore deprecation warnings we have no power over
                 import warnings
@@ -1000,6 +1001,18 @@ Resources:
                   plt.show()
                 except Exception:
                   print("Logs are not yet available.  It typically takes 25 minutes from the start of training for them to be available.")
+                # -
+
+                # ## Training and Evaluation Percentiles
+
+                # +
+                eval_percentiles = ["Evaluation", eval_complete_lr['time'].quantile(0.01), eval_complete_lr['time'].quantile(0.1), eval_complete_lr['time'].quantile(0.25), eval_complete_lr['time'].quantile(0.5), eval_complete_lr['time'].quantile(0.75)]
+                train_percentiles = ["Training", train_complete_lr['time'].quantile(0.01), train_complete_lr['time'].quantile(0.1), train_complete_lr['time'].quantile(0.25), train_complete_lr['time'].quantile(0.5), train_complete_lr['time'].quantile(0.75)]
+                percentile = pd.DataFrame(columns=['Description', '1st Percentile', '10th Percentile', '25th Percentile', '50th Percentile', '75th Percentile'])
+                percentile.loc[0] = eval_percentiles
+                percentile.loc[1] = train_percentiles
+                percentile.style \
+                  .format(precision=3)
                 # -
               mode : "000755"
               owner: ubuntu

--- a/standard-instance.yaml
+++ b/standard-instance.yaml
@@ -928,6 +928,7 @@ Resources:
                 from deepracer.logs import metrics
                 import matplotlib.pyplot as plt
                 import numpy as np
+                import pandas as pd
 
                 # Ignore deprecation warnings we have no power over
                 import warnings
@@ -961,6 +962,18 @@ Resources:
                   plt.show()
                 except Exception:
                   print("Logs are not yet available.  It typically takes 25 minutes from the start of training for them to be available.")
+                # -
+
+                # ## Training and Evaluation Percentiles
+
+                # +
+                eval_percentiles = ["Evaluation", eval_complete_lr['time'].quantile(0.01), eval_complete_lr['time'].quantile(0.1), eval_complete_lr['time'].quantile(0.25), eval_complete_lr['time'].quantile(0.5), eval_complete_lr['time'].quantile(0.75)]
+                train_percentiles = ["Training", train_complete_lr['time'].quantile(0.01), train_complete_lr['time'].quantile(0.1), train_complete_lr['time'].quantile(0.25), train_complete_lr['time'].quantile(0.5), train_complete_lr['time'].quantile(0.75)]
+                percentile = pd.DataFrame(columns=['Description', '1st Percentile', '10th Percentile', '25th Percentile', '50th Percentile', '75th Percentile'])
+                percentile.loc[0] = eval_percentiles
+                percentile.loc[1] = train_percentiles
+                percentile.style \
+                  .format(precision=3)
                 # -
               mode : "000755"
               owner: ubuntu


### PR DESCRIPTION
Added table with 1st, 10th, 25th, 50th and 75th percentile, so you can see if your model does occasionally fast laps, what it's capable of doing 1 in 10, 1 in 4, 1 in 2 etc. to the Training_and_Evaluation_Overview page under the graphs: -

![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/e6e4f961-d443-4041-a6a6-c7a6c91ddad5)
