### PR TITLE
feature/additional-percentiles

### DIFF
--- a/spot-instance.yaml
+++ b/spot-instance.yaml
@@ -1003,7 +1003,7 @@ Resources:
                   print("Logs are not yet available.  It typically takes 25 minutes from the start of training for them to be available.")
                 # -
 
-                # ## Training and Evaluation Percentiles
+                # ## Complete Lap Training and Evaluation Percentiles - All
 
                 # +
                 eval_percentiles = ["Evaluation", eval_complete_lr['time'].quantile(0.01), eval_complete_lr['time'].quantile(0.1), eval_complete_lr['time'].quantile(0.25), eval_complete_lr['time'].quantile(0.5), eval_complete_lr['time'].quantile(0.75)]
@@ -1012,6 +1012,20 @@ Resources:
                 percentile.loc[0] = eval_percentiles
                 percentile.loc[1] = train_percentiles
                 percentile.style \
+                  .format(precision=3)
+                # -
+
+                # ## Complete Lap Training and Evaluation Percentiles - Last 20 Evaluations, Last 40 Training Episodes
+
+                # +
+                train_complete_lr2=train_complete_lr.nlargest(40,['start_time'])
+                eval_complete_lr2=eval_complete_lr.nlargest(20,['start_time'])
+                eval_percentiles2 = ["Evaluation", eval_complete_lr2['time'].quantile(0.01), eval_complete_lr2['time'].quantile(0.1), eval_complete_lr2['time'].quantile(0.25), eval_complete_lr2['time'].quantile(0.5), eval_complete_lr2['time'].quantile(0.75)]
+                train_percentiles2 = ["Training", train_complete_lr2['time'].quantile(0.01), train_complete_lr2['time'].quantile(0.1), train_complete_lr2['time'].quantile(0.25), train_complete_lr2['time'].quantile(0.5), train_complete_lr2['time'].quantile(0.75)]
+                percentile2 = pd.DataFrame(columns=['Description', '1st Percentile', '10th Percentile', '25th Percentile', '50th Percentile', '75th Percentile'])
+                percentile2.loc[0] = eval_percentiles2
+                percentile2.loc[1] = train_percentiles2
+                percentile2.style \
                   .format(precision=3)
                 # -
               mode : "000755"

--- a/standard-instance.yaml
+++ b/standard-instance.yaml
@@ -964,7 +964,7 @@ Resources:
                   print("Logs are not yet available.  It typically takes 25 minutes from the start of training for them to be available.")
                 # -
 
-                # ## Training and Evaluation Percentiles
+                # ## Complete Lap Training and Evaluation Percentiles - All
 
                 # +
                 eval_percentiles = ["Evaluation", eval_complete_lr['time'].quantile(0.01), eval_complete_lr['time'].quantile(0.1), eval_complete_lr['time'].quantile(0.25), eval_complete_lr['time'].quantile(0.5), eval_complete_lr['time'].quantile(0.75)]
@@ -973,6 +973,20 @@ Resources:
                 percentile.loc[0] = eval_percentiles
                 percentile.loc[1] = train_percentiles
                 percentile.style \
+                  .format(precision=3)
+                # -
+
+                # ## Complete Lap Training and Evaluation Percentiles - Last 20 Evaluations, Last 40 Training Episodes
+
+                # +
+                train_complete_lr2=train_complete_lr.nlargest(40,['start_time'])
+                eval_complete_lr2=eval_complete_lr.nlargest(20,['start_time'])
+                eval_percentiles2 = ["Evaluation", eval_complete_lr2['time'].quantile(0.01), eval_complete_lr2['time'].quantile(0.1), eval_complete_lr2['time'].quantile(0.25), eval_complete_lr2['time'].quantile(0.5), eval_complete_lr2['time'].quantile(0.75)]
+                train_percentiles2 = ["Training", train_complete_lr2['time'].quantile(0.01), train_complete_lr2['time'].quantile(0.1), train_complete_lr2['time'].quantile(0.25), train_complete_lr2['time'].quantile(0.5), train_complete_lr2['time'].quantile(0.75)]
+                percentile2 = pd.DataFrame(columns=['Description', '1st Percentile', '10th Percentile', '25th Percentile', '50th Percentile', '75th Percentile'])
+                percentile2.loc[0] = eval_percentiles2
+                percentile2.loc[1] = train_percentiles2
+                percentile2.style \
                   .format(precision=3)
                 # -
               mode : "000755"


### PR DESCRIPTION
Added additional percentiles table that gives the last 20 evaluation and the last 40 training complete laps, to complete the existing percentiles that was provided for all training and evaluations.

The intent is this new table provides a more likely end result when the model is evaluated, as it only considers performance near the end of the training, not the entire historic laps.