### PR TITLE
5 min analysis and video link

### DIFF
--- a/spot-instance.yaml
+++ b/spot-instance.yaml
@@ -193,8 +193,8 @@ Resources:
                 <html>
                 <body>
 
-                <h2>Watch Live Video Feed</h2>
-                <p><a href="update_to_video_url">Output</a></p>
+                <h2>Video Feed</h2>
+                <p><a href="update_to_video_url">Watch Live Video</a></p>
                                 
                 <h2>All logs summary in one view</h2>
                 <p><a href="output.txt">Output</a></p>

--- a/spot-instance.yaml
+++ b/spot-instance.yaml
@@ -194,7 +194,7 @@ Resources:
                 <body>
 
                 <h2>Video Feed</h2>
-                <p><a href="?robo=all&camera=kvs_stream&quality=75&width=480">Watch Live Video</a></p>
+                <p><a href="/?robo=all&camera=kvs_stream&quality=75&width=480">Watch Live Video</a></p>
                                 
                 <h2>All logs summary in one view</h2>
                 <p><a href="output.txt">Output</a></p>

--- a/spot-instance.yaml
+++ b/spot-instance.yaml
@@ -194,7 +194,7 @@ Resources:
                 <body>
 
                 <h2>Video Feed</h2>
-                <p><a href="update_to_video_url">Watch Live Video</a></p>
+                <p><a href="?robo=all&camera=kvs_stream&quality=75&width=480">Watch Live Video</a></p>
                                 
                 <h2>All logs summary in one view</h2>
                 <p><a href="output.txt">Output</a></p>
@@ -532,10 +532,8 @@ Resources:
                 PUBLIC_IP=$(curl http://169.254.169.254/latest/meta-data/public-ipv4)
 
                 JUPYTER_URL=http://$PUBLIC_IP:8888/?$TOKEN
-                VIDEO_URL=http://$PUBLIC_IP:8100/?robo=all&camera=kvs_stream&quality=75&width=480
 
                 sudo sed -i "s|update_to_jupyter_url|${JUPYTER_URL}|" /home/ubuntu/bin/menu.html
-                sudo sed -i "s|update_to_video_url|${VIDEO_URL}|" /home/ubuntu/bin/menu.html
 
                 S3_PREFIX_FOR_ANALYSIS=$(cat run.env | grep DR_LOCAL_S3_MODEL_PREFIX= | awk -F'=' '{print $2}')
                 DEEPRACER_TRACK=$(cat run.env | grep DR_WORLD_NAME= | awk -F'=' '{print $2}')

--- a/spot-instance.yaml
+++ b/spot-instance.yaml
@@ -192,6 +192,9 @@ Resources:
                 <!DOCTYPE html>
                 <html>
                 <body>
+
+                <h2>Watch Live Video Feed</h2>
+                <p><a href="update_to_video_url">Output</a></p>
                                 
                 <h2>All logs summary in one view</h2>
                 <p><a href="output.txt">Output</a></p>
@@ -437,7 +440,7 @@ Resources:
                   if [[ ! -f /home/ubuntu/bin/termination.started ]];then
                     cp $USAGE_OUTPUT /tmp/logs/ > /dev/null 2>&1
                   fi
-                  sleep 60
+                  sleep 300
                 done
               mode : "000755"
               owner: ubuntu
@@ -529,8 +532,10 @@ Resources:
                 PUBLIC_IP=$(curl http://169.254.169.254/latest/meta-data/public-ipv4)
 
                 JUPYTER_URL=http://$PUBLIC_IP:8888/?$TOKEN
+                VIDEO_URL=http://$PUBLIC_IP:8100/?robo=all&camera=kvs_stream&quality=75&width=480
 
                 sudo sed -i "s|update_to_jupyter_url|${JUPYTER_URL}|" /home/ubuntu/bin/menu.html
+                sudo sed -i "s|update_to_video_url|${VIDEO_URL}|" /home/ubuntu/bin/menu.html
 
                 S3_PREFIX_FOR_ANALYSIS=$(cat run.env | grep DR_LOCAL_S3_MODEL_PREFIX= | awk -F'=' '{print $2}')
                 DEEPRACER_TRACK=$(cat run.env | grep DR_WORLD_NAME= | awk -F'=' '{print $2}')

--- a/standard-instance.yaml
+++ b/standard-instance.yaml
@@ -153,7 +153,7 @@ Resources:
                 <body>
 
                 <h2>Video Feed</h2>
-                <p><a href="?robo=all&camera=kvs_stream&quality=75&width=480">Watch Live Video</a></p>
+                <p><a href="/?robo=all&camera=kvs_stream&quality=75&width=480">Watch Live Video</a></p>
                                 
                 <h2>All logs summary in one view</h2>
                 <p><a href="output.txt">Output</a></p>

--- a/standard-instance.yaml
+++ b/standard-instance.yaml
@@ -151,6 +151,9 @@ Resources:
                 <!DOCTYPE html>
                 <html>
                 <body>
+
+                <h2>Watch Live Video Feed</h2>
+                <p><a href="update_to_video_url">Output</a></p>
                                 
                 <h2>All logs summary in one view</h2>
                 <p><a href="output.txt">Output</a></p>
@@ -397,7 +400,7 @@ Resources:
                   if [[ ! -f /home/ubuntu/bin/termination.started ]];then
                     cp $USAGE_OUTPUT /tmp/logs/ > /dev/null 2>&1
                   fi
-                  sleep 60
+                  sleep 300
                 done
               mode : "000755"
               owner: ubuntu
@@ -490,8 +493,10 @@ Resources:
                 PUBLIC_IP=$(curl http://169.254.169.254/latest/meta-data/public-ipv4)
 
                 JUPYTER_URL=http://$PUBLIC_IP:8888/?$TOKEN
+                VIDEO_URL=http://$PUBLIC_IP:8100/?robo=all&camera=kvs_stream&quality=75&width=480
 
                 sudo sed -i "s|update_to_jupyter_url|${JUPYTER_URL}|" /home/ubuntu/bin/menu.html
+                sudo sed -i "s|update_to_video_url|${VIDEO_URL}|" /home/ubuntu/bin/menu.html
 
                 S3_PREFIX_FOR_ANALYSIS=$(cat run.env | grep DR_LOCAL_S3_MODEL_PREFIX= | awk -F'=' '{print $2}')
                 DEEPRACER_TRACK=$(cat run.env | grep DR_WORLD_NAME= | awk -F'=' '{print $2}')

--- a/standard-instance.yaml
+++ b/standard-instance.yaml
@@ -152,8 +152,8 @@ Resources:
                 <html>
                 <body>
 
-                <h2>Watch Live Video Feed</h2>
-                <p><a href="update_to_video_url">Output</a></p>
+                <h2>Video Feed</h2>
+                <p><a href="update_to_video_url">Watch Live Video</a></p>
                                 
                 <h2>All logs summary in one view</h2>
                 <p><a href="output.txt">Output</a></p>

--- a/standard-instance.yaml
+++ b/standard-instance.yaml
@@ -153,7 +153,7 @@ Resources:
                 <body>
 
                 <h2>Video Feed</h2>
-                <p><a href="update_to_video_url">Watch Live Video</a></p>
+                <p><a href="?robo=all&camera=kvs_stream&quality=75&width=480">Watch Live Video</a></p>
                                 
                 <h2>All logs summary in one view</h2>
                 <p><a href="output.txt">Output</a></p>
@@ -493,10 +493,8 @@ Resources:
                 PUBLIC_IP=$(curl http://169.254.169.254/latest/meta-data/public-ipv4)
 
                 JUPYTER_URL=http://$PUBLIC_IP:8888/?$TOKEN
-                VIDEO_URL=http://$PUBLIC_IP:8100/?robo=all&camera=kvs_stream&quality=75&width=480
 
                 sudo sed -i "s|update_to_jupyter_url|${JUPYTER_URL}|" /home/ubuntu/bin/menu.html
-                sudo sed -i "s|update_to_video_url|${VIDEO_URL}|" /home/ubuntu/bin/menu.html
 
                 S3_PREFIX_FOR_ANALYSIS=$(cat run.env | grep DR_LOCAL_S3_MODEL_PREFIX= | awk -F'=' '{print $2}')
                 DEEPRACER_TRACK=$(cat run.env | grep DR_WORLD_NAME= | awk -F'=' '{print $2}')


### PR DESCRIPTION
Moving updated to log analysis etc to every 5 minutes, instead of 1 minute, to reduce S3 costs as I've noticed a lot of S3 requests are being generated, e.g. for around 30 hours running: -
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/3f95113c-86b1-4601-8540-dcde58f09d41)

Also added a link from the menu to watch the video feed: -
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/07afec9f-a310-41fd-ae80-855e8629d0b4)

Which links to
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/e6824167-40f2-4ab9-ade9-a13a7140df13)


