### PR TITLE
stop training gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Simply run:
 
 ### Stopping training
 
-The script stop-instance.sh executes 'safe termination' of training and deletes the cloudformation stack used to create the instance. This command works for both standard and spot instances. The scripts takes one parameter, the name of the stack used to create the instance (this is the same as the second parameter to used to create the instance with either create-standard-instance.sh or create-spot-instance.sh commands). For example: `./stop-instance.sh my-instance-stack-name` . You can also go to cloudformation and manually delete the stack.
+The script stop-training.sh executes 'safe termination' of training by updated the CloudFroamtion stack to gracefully complete the training in 2 minutes time from when the script is ran. This command works for both standard and spot instances. The scripts takes one parameter, the name of the stack used to create the instance (this is the same as the second parameter used to create the instance with either create-standard-instance.sh or create-spot-instance.sh commands). For example: `./stop-instance.sh my-instance-stack-name` . You can also go to cloudformation and manually delete the stack, but if you do that you wont' get graceful termination (i.e. upload of model to DeepRacer Console or S3 upload to your 'upload' bucket)
 
 ### Adding additional IP addresses to security group ingress and NACLs
 

--- a/spot-instance.yaml
+++ b/spot-instance.yaml
@@ -13,7 +13,7 @@ Parameters:
     Type: Number
     Description: timeout in minutes after which training is stopped and this stack is deleted
     Default: 60
-    MinValue: 10
+    MinValue: 2
     MaxValue: 1440 # 24 hours
   AmiId:
     Type: String

--- a/standard-instance.yaml
+++ b/standard-instance.yaml
@@ -13,7 +13,7 @@ Parameters:
     Type: Number
     Description: timeout in minutes after which training is stopped and this stack is deleted
     Default: 60
-    MinValue: 0
+    MinValue: 2
     MaxValue: 1440 # 24 hours
   AmiId:
     Type: String

--- a/stop-training.sh
+++ b/stop-training.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -xa
+
+stackName=$1
+shift
+
+timeToLiveInMinutes=2
+shift
+
+aws cloudformation update-stack --stack-name $stackName --use-previous-template --parameters  ParameterKey=TimeToLiveInMinutes,ParameterValue=$timeToLiveInMinutes ParameterKey=BUCKET,UsePreviousValue=true ParameterKey=ResourcesStackName,UsePreviousValue=true ParameterKey=DeepRacerImportName,UsePreviousValue=true ParameterKey=CUSTOMFILELOCATION,UsePreviousValue=true ParameterKey=AmiId,UsePreviousValue=true --capabilities CAPABILITY_IAM
+echo "Training will stop in " $timeToLiveInMinutes " minutes"


### PR DESCRIPTION
Added script to gracefully complete training by updating the stack with a 2 minute ttl, so the event brdieg then runs and cleans everything up and uploads the model

Created stack to run for 60 mins: -
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/79da976a-838f-4900-b0ad-8344df6cd30d)

Event bridge due to finish at 12:45:-
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/524b64b8-6967-42c4-9d5c-bd70a9289804)

Got notification of training started at 11:45
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/c45ea443-ee0b-48cf-a3a0-ab5028cedfd9)

Ran stop-training script: -
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/d23e0ae4-1510-47c5-9447-2398b1b559ef)

Stack updated with 2 minute ttl
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/baae3522-58e1-417f-9279-9f39af6d1450)

Event bridge updated to 11:50
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/bb6cbf8e-0094-40af-8e0e-dc4921fbc15c)

Training notifcation ended received 11:51: -
![image](https://github.com/aws-deepracer-community/deepracer-on-the-spot/assets/53598199/01519190-8622-40d4-9f05-b0c221a927e6)


