### PR TITLE
Upgrade Ubuntu to 22.04

### DIFF
--- a/scripts/image-builder.yaml
+++ b/scripts/image-builder.yaml
@@ -78,7 +78,7 @@ Resources:
   UbuntuServerImageInfrastructureConfiguration:
     Type: AWS::ImageBuilder::InfrastructureConfiguration
     Properties:
-      Name: !Sub 'UbuntuServer20-Image-Infrastructure-Configuration-${AWS::StackName}'
+      Name: !Sub 'UbuntuServer22-Image-Infrastructure-Configuration-${AWS::StackName}'
       InstanceProfileName: !Ref 'InstanceProfile'
       InstanceTypes: !Ref 'BuildInstanceType'
       Logging:
@@ -461,8 +461,8 @@ Resources:
     Type: AWS::ImageBuilder::ImageRecipe
     Properties:
       Name: !Sub 'UbuntuServerForDeepRacer-${AWS::StackName}'
-      Version: '0.0.4'
-      ParentImage: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:image/ubuntu-server-20-lts-x86/x.x.x'
+      Version: '0.0.5'
+      ParentImage: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:image/ubuntu-server-22-lts-x86/x.x.x'
       Components:
         - ComponentArn: !Ref 'CreateLogsComponent'
         - ComponentArn: !Ref 'SafeTerminationComponent'

--- a/spot-instance.yaml
+++ b/spot-instance.yaml
@@ -469,7 +469,6 @@ Resources:
                   sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/$distribution/x86_64/7fa2af80.pub
                   echo "deb http://developer.download.nvidia.com/compute/cuda/repos/$distribution/x86_64 /" | sudo tee /etc/apt/sources.list.d/cuda.list
                   echo "deb http://developer.download.nvidia.com/compute/machine-learning/repos/$distribution/x86_64 /" | sudo tee /etc/apt/sources.list.d/cuda_learn.list
-                  sudo apt install -y nvidia-driver-525-server --no-install-recommends -o Dpkg::Options::="--force-overwrite"
                   distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
                   curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
                   curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list

--- a/standard-instance.yaml
+++ b/standard-instance.yaml
@@ -430,7 +430,6 @@ Resources:
                   sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/$distribution/x86_64/7fa2af80.pub
                   echo "deb http://developer.download.nvidia.com/compute/cuda/repos/$distribution/x86_64 /" | sudo tee /etc/apt/sources.list.d/cuda.list
                   echo "deb http://developer.download.nvidia.com/compute/machine-learning/repos/$distribution/x86_64 /" | sudo tee /etc/apt/sources.list.d/cuda_learn.list
-                  sudo apt install -y nvidia-driver-525-server --no-install-recommends -o Dpkg::Options::="--force-overwrite"
                   distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
                   curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
                   curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list


### PR DESCRIPTION
Update DOTS to run on Ubuntu 22.04.  This not only moves the OS onto a later version, but it also ensure the nvidia drivers will move to 550, which are required for stability on the new g6 instance types.

also removed the forcing of certain driver versions when OpenGL is used, as it's not required and interferes with the 550 versions.