### PR TITLE
Changed stop-training.sh script to check aws command return code and validate required argument

### DIFF
--- a/stop-training.sh
+++ b/stop-training.sh
@@ -2,6 +2,11 @@
 
 set -xa
 
+if [ $# -eq 0 ]; then
+   echo "Required model name to stop training not provided"
+   exit 1
+fi
+
 stackName=$1
 shift
 
@@ -9,4 +14,10 @@ timeToLiveInMinutes=2
 shift
 
 aws cloudformation update-stack --stack-name $stackName --use-previous-template --parameters  ParameterKey=TimeToLiveInMinutes,ParameterValue=$timeToLiveInMinutes ParameterKey=BUCKET,UsePreviousValue=true ParameterKey=ResourcesStackName,UsePreviousValue=true ParameterKey=DeepRacerImportName,UsePreviousValue=true ParameterKey=CUSTOMFILELOCATION,UsePreviousValue=true ParameterKey=AmiId,UsePreviousValue=true --capabilities CAPABILITY_IAM
-echo "Training will stop in " $timeToLiveInMinutes " minutes"
+
+if [ $? -eq 0 ]; then
+    echo "Training will stop in " $timeToLiveInMinutes " minutes"
+else
+    echo "Error trying to stop training"
+fi
+


### PR DESCRIPTION
stop-training.sh script checks for aws command return code.
If success (ret code = 0) prints current message about stopping model in 2 minutes.
If not success (ret code <> 0) prints error message

Additionally, prints a message if required stack name argument is not provided

Fix for issue #153