### PR TITLE
Adding stack name to RunShellScript log group to allow mulptiple base stacks within the same sandbox

### DIFF
--- a/base-resources.yaml
+++ b/base-resources.yaml
@@ -356,7 +356,7 @@ Resources:
               try:
                   response = ssm_client.send_command(
                       InstanceIds=[instance],
-                      DocumentName='AWS-RunShellScript',
+                      DocumentName='${AWS::StackName}AWS-RunShellScript',
                       Parameters={'commands': ['su - ubuntu bash -lc /home/ubuntu/bin/safe_termination.sh']},
                       CloudWatchOutputConfig={'CloudWatchOutputEnabled': True},
                       TimeoutSeconds=60)
@@ -537,4 +537,4 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       RetentionInDays: 7
-      LogGroupName: !Sub '/aws/ssm/AWS-RunShellScript'
+      LogGroupName: !Sub '/aws/ssm/${AWS::StackName}AWS-RunShellScript'

--- a/spot-instance.yaml
+++ b/spot-instance.yaml
@@ -1276,7 +1276,7 @@ Resources:
               try:
                   response = ssm_client.send_command(
                       InstanceIds=[instance_id],
-                      DocumentName='AWS-RunShellScript',
+                      DocumentName='${AWS::StackName}AWS-RunShellScript',
                       Parameters={'commands': ['su - ubuntu bash -lc /home/ubuntu/deepracer-for-cloud/interrupt_spot.sh']},
                       CloudWatchOutputConfig={'CloudWatchOutputEnabled': True},
                       TimeoutSeconds=90)


### PR DESCRIPTION
Fixes #189

Adding stack name variable to RunShellScript log group to allow mulptiple base stacks within the same sandbox