### PR TITLE
bugfix/temp-disable-ssm-log-creation

### DIFF
--- a/base-resources.yaml
+++ b/base-resources.yaml
@@ -533,8 +533,10 @@ Resources:
         ServiceToken: !GetAtt QuotaLambda.Arn
         FunctionName: !Ref QuotaLambda
 
-  SSMShellScriptLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      RetentionInDays: 7
-      LogGroupName: !Sub '/aws/ssm/AWS-RunShellScript'
+  ##Temporaily disable to allow multip base resources to be created in same region
+  ## TODO - find a method to conditionally create this resource
+  #SSMShellScriptLogGroup:
+  #  Type: AWS::Logs::LogGroup
+  #  Properties:
+  #    RetentionInDays: 7
+  #    LogGroupName: !Sub '/aws/ssm/AWS-RunShellScript'


### PR DESCRIPTION
Disable CloudFormation creation of SSM Docs log group in cloudwatch.

This means the logs will be retained for ever, and not deleted when the base stack is deleted, however it does allow multiple base stacks in each region to be deployed.

Should be considered a temp fix whilst a more permanent fix to conditionally create the log group with 7 day retention is developed.